### PR TITLE
Applied `ridi.impala` package name and added ImpalaConfig class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*names, **kwargs):
 
 setup(
     name='ridi-impala-connector',
-    version='0.4.0',
+    version='0.4.0-RIDI',
     license='MIT',
     description='ridi-impala-connector',
     long_description='%s' % read('README.md'),

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def read(*names, **kwargs):
 
 setup(
     name='ridi-impala-connector',
-    version='0.3.0',
+    version='0.4.0',
     license='MIT',
     description='ridi-impala-connector',
     long_description='%s' % read('README.md'),

--- a/src/ridi/impala/__init__.py
+++ b/src/ridi/impala/__init__.py
@@ -1,6 +1,6 @@
 from impala.dbapi import connect as impala_connect
 from impala.error import Error as impala_Error
-from ridi.settings import IMPALA_CONNECT_ARGS
+from .config import IMPALA_CONNECT_ARGS
 import logging
 
 logger = logging.getLogger(__name__)
@@ -105,4 +105,4 @@ def date_eq_condition(the_date):
 
 DATE_AS_STRING = "CONCAT(LPAD(CAST(year AS STRING),4,'0'),'-',LPAD(CAST(month AS STRING),2,'0'),'-',LPAD(CAST(day AS STRING),2,'0'))"
 
-IMPALA_CLIENT = ImpalaThriftClient(IMPALA_CONNECT_ARGS)
+IMPALA_CLIENT = ImpalaThriftClient(IMPALA_CONNECT_ARGS.as_dict())

--- a/src/ridi/impala/config.py
+++ b/src/ridi/impala/config.py
@@ -1,0 +1,32 @@
+from collections import namedtuple
+
+ConnectArgsType = namedtuple('ConnectArgsTuple', [
+    'host', 'port', 'user', 'password', 'database'
+])
+
+IMPALA_CONNECT_ARGS = ConnectArgsType(
+    host="localhost",
+    port=21050,
+    user="user",
+    password="password",
+    database="default",
+)
+
+
+class ImpalaConfig(object):
+    @staticmethod
+    def set_host(host):
+        IMPALA_CONNECT_ARGS.host = host
+
+    @staticmethod
+    def set_port(port):
+        IMPALA_CONNECT_ARGS.port = port
+
+    @staticmethod
+    def set_auth(user, password):
+        IMPALA_CONNECT_ARGS.user = user
+        IMPALA_CONNECT_ARGS.password = password
+
+    @staticmethod
+    def set_database(database):
+        IMPALA_CONNECT_ARGS.database = database


### PR DESCRIPTION
- [스타일 가이드](https://github.com/ridi/style-guide/tree/master/Python#library-%EA%B0%9C%EB%B0%9C%EC%8B%9C)에 따라 라이브러리의 최상위 패키지를 ridi 로 변경
- `ridi.settings` 모듈에 대한 참조를 없애고, 설정에 대한 setter 함수 추가
